### PR TITLE
feat(core): Define component name in idf_component.yml

### DIFF
--- a/components/core/idf_component.yml
+++ b/components/core/idf_component.yml
@@ -1,4 +1,5 @@
 ## Synapse Core Component Manifest
+name: synapse
 version: "11.0.0"
 description: Synapse IoT Framework Core Component.
 url: https://github.com/magradze/synapse


### PR DESCRIPTION
Explicitly sets the component name to 'synapse' in the manifest file. This provides a clear and unique identifier for the IDF Component Manager, improving clarity and preventing potential naming conflicts when used as a dependency.